### PR TITLE
✨ feat(apps): support multiple launcher activities per app

### DIFF
--- a/app/schemas/com.minimo.launcher.data.AppDatabase/1.json
+++ b/app/schemas/com.minimo.launcher.data.AppDatabase/1.json
@@ -2,12 +2,18 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "228ffaaeeebb672d8db44b4e38dcf0a8",
+    "identityHash": "548d0903b25a391220ba4ac72535646d",
     "entities": [
       {
         "tableName": "appInfoEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`package_name` TEXT NOT NULL, `app_name` TEXT NOT NULL, `alternate_app_name` TEXT NOT NULL DEFAULT '', `is_favourite` INTEGER NOT NULL DEFAULT 0, `is_hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`package_name`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`class_name` TEXT NOT NULL, `package_name` TEXT NOT NULL, `app_name` TEXT NOT NULL, `alternate_app_name` TEXT NOT NULL DEFAULT '', `is_favourite` INTEGER NOT NULL DEFAULT 0, `is_hidden` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`class_name`))",
         "fields": [
+          {
+            "fieldPath": "className",
+            "columnName": "class_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
           {
             "fieldPath": "packageName",
             "columnName": "package_name",
@@ -45,14 +51,14 @@
         "primaryKey": {
           "autoGenerate": false,
           "columnNames": [
-            "package_name"
+            "class_name"
           ]
         }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '228ffaaeeebb672d8db44b4e38dcf0a8')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '548d0903b25a391220ba4ac72535646d')"
     ]
   }
 }

--- a/app/src/main/java/com/minimo/launcher/data/entities/AppInfoEntity.kt
+++ b/app/src/main/java/com/minimo/launcher/data/entities/AppInfoEntity.kt
@@ -7,6 +7,9 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "appInfoEntity")
 data class AppInfoEntity(
     @PrimaryKey
+    @ColumnInfo(name = "class_name")
+    val className: String,
+
     @ColumnInfo(name = "package_name")
     val packageName: String,
 

--- a/app/src/main/java/com/minimo/launcher/data/usecase/UpdateAllAppsUseCase.kt
+++ b/app/src/main/java/com/minimo/launcher/data/usecase/UpdateAllAppsUseCase.kt
@@ -48,13 +48,14 @@ class UpdateAllAppsUseCase @Inject constructor(
         installedApps: List<InstalledApp>,
         dbApps: List<AppInfoEntity>
     ) {
-        val dbAppsPackages = dbApps.map { it.packageName }
+        val dbAppsPackages = dbApps.map { it.className }
         for (installedApp in installedApps) {
-            if (installedApp.packageName !in dbAppsPackages) {
+            if (installedApp.className !in dbAppsPackages) {
                 appInfoDao.addApps(
                     AppInfoEntity(
                         packageName = installedApp.packageName,
                         appName = installedApp.appName,
+                        className = installedApp.className,
                         alternateAppName = installedApp.appName,
                         isFavourite = false,
                         isHidden = false

--- a/app/src/main/java/com/minimo/launcher/ui/entities/AppInfo.kt
+++ b/app/src/main/java/com/minimo/launcher/ui/entities/AppInfo.kt
@@ -3,6 +3,7 @@ package com.minimo.launcher.ui.entities
 data class AppInfo(
     val packageName: String,
     val appName: String,
+    val className: String,
     val alternateAppName: String,
     val isFavourite: Boolean,
     val isHidden: Boolean

--- a/app/src/main/java/com/minimo/launcher/ui/favourite_apps/FavouriteAppsScreen.kt
+++ b/app/src/main/java/com/minimo/launcher/ui/favourite_apps/FavouriteAppsScreen.kt
@@ -114,7 +114,7 @@ fun FavouriteAppsScreen(
                 modifier = Modifier.weight(1f),
                 contentPadding = PaddingValues(vertical = 20.dp)
             ) {
-                items(items = state.filteredAllApps, key = { it.packageName }) { appInfo ->
+                items(items = state.filteredAllApps, key = { it.className }) { appInfo ->
                     ToggleAppItem(
                         modifier = Modifier.animateItem(),
                         appName = appInfo.name,

--- a/app/src/main/java/com/minimo/launcher/ui/hidden_apps/HiddenAppsScreen.kt
+++ b/app/src/main/java/com/minimo/launcher/ui/hidden_apps/HiddenAppsScreen.kt
@@ -114,7 +114,7 @@ fun HiddenAppsScreen(
                 modifier = Modifier.weight(1f),
                 contentPadding = PaddingValues(vertical = 20.dp)
             ) {
-                items(items = state.filteredAllApps, key = { it.packageName }) { appInfo ->
+                items(items = state.filteredAllApps, key = { it.className }) { appInfo ->
                     ToggleAppItem(
                         modifier = Modifier.animateItem(),
                         appName = appInfo.name,

--- a/app/src/main/java/com/minimo/launcher/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/minimo/launcher/ui/home/HomeScreen.kt
@@ -266,7 +266,7 @@ fun HomeScreen(
                         .weight(1f),
                     contentPadding = PaddingValues(top = 16.dp, bottom = systemNavigationHeight)
                 ) {
-                    items(items = state.filteredAllApps, key = { it.packageName }) { appInfo ->
+                    items(items = state.filteredAllApps, key = { it.className }) { appInfo ->
                         AppNameItem(
                             modifier = Modifier.animateItem(),
                             appName = appInfo.name,
@@ -346,7 +346,7 @@ fun HomeScreen(
                         contentPadding = paddingValues,
                         verticalArrangement = Arrangement.Center
                     ) {
-                        items(items = state.favouriteApps, key = { it.packageName }) { appInfo ->
+                        items(items = state.favouriteApps, key = { it.className }) { appInfo ->
                             AppNameItem(
                                 modifier = Modifier.animateItem(),
                                 appName = appInfo.name,


### PR DESCRIPTION
### Summary
This update enhances app handling by uniquely identifying each launcher activity using its `className`, rather than only the `packageName`. This enables proper support for apps with multiple launcher components.

### ✅ Changes

- **Database**
  - Added `class_name` column to `appInfoEntity`
  - Changed primary key from `package_name` to `class_name`
  - Updated Room schema identity hash and schema file accordingly

- **Entities & Use Cases**
  - Modified `AppInfoEntity` to include `className`
  - Updated `UpdateAllAppsUseCase` to prevent duplicate entries based on `className`

- **App Discovery**
  - `getInstalledApps()` now returns both `packageName` and `className`
  - Added detailed `Timber` debug logs for each discovered launcher activity

- **UI**
  - Replaced `LazyColumn` keys from `packageName` to `className` in:
    - `HomeScreen.kt`
    - `FavouriteAppsScreen.kt`
    - `HiddenAppsScreen.kt`
  - Prevents Compose runtime crashes due to non-unique keys

- **Models**
  - Updated `InstalledApp` and `AppInfo` to include `className` field

### 🧠 Why

Some apps declare multiple launcher activities under a single package. Previously, using `packageName` alone caused:
- Missing entries in the database
- Crashes in Jetpack Compose's `LazyColumn` due to duplicate keys

Switching to `className` as the unique key resolves these issues and ensures consistent behavior across the system.



Closes #25